### PR TITLE
Set meta theme-color to orange

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,6 +8,7 @@
           <meta name="author" content="{{ site.links.github }}">
         {% endif %}
         <meta name="title" content="{{ page.title }}" >
+        <meta name="theme-color" content="#e87722">
         <link rel="icon" type="image/png" href="{{site.url}}/favicon.png">
         <meta name="viewport" content="width=device-width, initial-scale=1">
         {% include ssn.html %}


### PR DESCRIPTION
This changes the browser theme color for certain browsers (chrome mobile, vivaldi). Previous theme color was based on colors on the page, which was kind of awful.
